### PR TITLE
close on exception

### DIFF
--- a/odetteftp/core/pom.xml
+++ b/odetteftp/core/pom.xml
@@ -92,8 +92,6 @@ limitations under the License.
                             !com.google.protobuf,
                             *
                         </Import-Package>
-                        <Embed-Dependency>netty</Embed-Dependency>
-                        <!--<Bundle-Activator>com.apogado.oftp2.oftplet.Activator</Bundle-Activator>-->
                     </instructions>
                 </configuration>
             </plugin>

--- a/odetteftp/core/src/main/java/org/neociclo/odetteftp/netty/OdetteFtpChannelHandler.java
+++ b/odetteftp/core/src/main/java/org/neociclo/odetteftp/netty/OdetteFtpChannelHandler.java
@@ -400,5 +400,7 @@ public class OdetteFtpChannelHandler extends IdleStateAwareChannelHandler {
         Oftplet oftplet = getSessionOftplet(session);
 
         oftplet.onExceptionCaught(e.getCause());
+        
+        ctx.getChannel().close();
     }
 }


### PR DESCRIPTION
The protocol is unrecoverable on exception anyway and close operation will clear write buff preventing WRITE_OP interest on NIO selectors  from eating CPU
